### PR TITLE
Introduce optional subject-less messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Sole purpose of this library is to generate validation error messages to provide
  var Message = require('cressida').create();
  
  Message('foo', '!empty') // foo should not be empty.
+ Message('len', [10, 20]) // should be between 10 to 20 characters.
 ```
 Cressida supports numerous operators such as: 
 ```
@@ -75,7 +76,7 @@ Every operator can be either positive or negative using `!`, `is` and/or `not` p
 
 ### Options
 
-Right now, Cressida only supports to change auxiliary verb in the message that is `should` by default.
+Cressida supports to change auxiliary verb in the message that is `should` by default.
 
 ``` javascript
  var Message = require('cressida').create({ auxiliary : 'must' });
@@ -83,6 +84,13 @@ Right now, Cressida only supports to change auxiliary verb in the message that i
  Message('foo', '!empty') // foo must not be empty.
 ```
 
+It also support to omit names from the messages.
+
+``` javascript
+ var Message = require('cressida').create({ includeName: false });
+ 
+ Message('foo', '!empty') // should not be empty.
+```
 ### Examples
 
 ``` javascript

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Cressida supports to change auxiliary verb in the message that is `should` by de
  Message('foo', '!empty') // foo must not be empty.
 ```
 
-It also support to omit names from the messages.
+It also supports to omit names from the messages.
 
 ``` javascript
  var Message = require('cressida').create({ includeName: false });

--- a/src/classes/cressida.js
+++ b/src/classes/cressida.js
@@ -6,23 +6,36 @@
 'use strict';
 
 const DEFAULTS = {
-  auxiliary: 'should'
+  auxiliary: 'should',
+  includeName: true
 };
 
 import Parser from './parser';
 
 export default class Cressida {
-  static message(name, operator, args) {
-    if (typeof operator === 'undefined' || !operator) throw new Error('Operator can\'t be empty.');
+  /**
+   * Core method to generate messages.
+   *
+   * @returns {*}
+   */
+  static message() {
+    let [_name, _raw, _args] = Parser.args(...arguments);
+    if (typeof _raw === 'undefined' || !_raw) throw new Error('Operator can\'t be empty.');
 
-    let [_not, _operator, _type] = Parser.operator(operator);
+    let [_not, _operator, _type] = Parser.operator(_raw);
     let options = Cressida._options;
     let base = `${options.auxiliary} ${ _not ? 'not be' : 'be'}`;
-    let suffix = Parser.methods[_type](_operator, args);
+    let suffix = Parser.methods[_type](_operator, _args);
 
-    return `${name} ${base} ${suffix}.`;
+    return (options.includeName && typeof _name !== 'undefined') ? `${_name} ${base} ${suffix}.` : `${base} ${suffix}.`;
   }
 
+  /**
+   * Factory method that return the main function to generate messages.
+   *
+   * @param options
+   * @returns {Cressida.message}
+   */
   static create(options) {
     Cressida._options = Object.assign({}, DEFAULTS, options);
     return Cressida.message;

--- a/src/classes/parser.js
+++ b/src/classes/parser.js
@@ -11,7 +11,8 @@ const TYPES = {
   STRING: ['contains', 'alphanumeric', 'equals', 'alpha', 'len', 'length', 'lowercase', 'uppercase'],
   STANDALONE: ['email', 'url', 'ip', 'uuid', 'array', 'creditcard', 'int', 'float', 'decimal', 'date'],
   BOOL: ['boolean'],
-  ARRAY: ['in']
+  ARRAY: ['in'],
+  NONE: ['empty']
 };
 
 const STANDALONE = {
@@ -57,6 +58,15 @@ import { humanize } from '../utils';
 
 export default class Parser {
 
+  /**
+   * Static method to parse operator.
+   *
+   * Possible inputs can be:
+   * - Positives: empty, isEmpty, !notEmpty, !isNotEmpty
+   * - Negatives: !empty, !isEmpty, notEmpty
+   * @param operator
+   * @returns {*[]}
+   */
   static operator(operator) {
     let _count = 0;
     let _not = false;
@@ -79,13 +89,24 @@ export default class Parser {
     return [_not, _operator, _type];
   }
 
+  /**
+   * Static method to get the type of the operator.
+   *
+   * @param operator
+   * @returns {string}
+   */
   static type(operator) {
+    if (!Parser.isSupported(operator)) throw new Error(`Provided operator \`${operator}\` is not supported.`);
     for (let type of Object.keys(TYPES)) {
       if (TYPES[type].includes(operator)) return String(type).toLowerCase();
     }
-    return 'none';
   }
 
+  /**
+   * Static method that wraps all type wise operations.
+   *
+   * @returns {*}
+   */
   static get methods() {
     return {
       date() {
@@ -129,5 +150,42 @@ export default class Parser {
     };
   }
 
-;
+  /**
+   * Return true if provided operator is valid.
+   *
+   * @param operator
+   * @returns {*}
+   */
+  static isSupported(operator) {
+    let _all = [];
+    for (let type of Object.keys(TYPES)) {
+      _all.push(...TYPES[type]);
+    }
+    return Parser._containsAny(operator.toLowerCase(), _all);
+  }
+
+  /**
+   * Search through an array and returns true if any value of array matches the provided needle.
+   *
+   * @param needle
+   * @param haystack
+   * @returns {boolean}
+   * @private
+   */
+  static _containsAny(needle, haystack) {
+    for (let straw of haystack) {
+      if (needle.includes(straw)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Parse arguments.
+   *
+   * @returns {*[]}
+   */
+  static args() {
+    let [_first, _second, _third] = Array.from(arguments);
+    return Parser.isSupported(_first) ? [_third, _first, _second] : [_first, _second, _third];
+  }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,12 @@
 
 const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
+/**
+ * Makes date a bit more humane.
+ *
+ * @param value
+ * @returns {*}
+ */
 export function humanize(value) {
   let _date = (typeof value === 'undefined') ? new Date() : new Date(value);
 

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@
  * Created by Umayr Shahid on 8/18/2015.
  */
 
+/* eslint-env node, mocha */
 'use strict';
 
 import { equal } from 'assert';
@@ -19,10 +20,12 @@ function make(operator, message, args, instance = Cressida.create()) {
 
   positives.map((o) => {
     equal(instance('foo', o, args), `foo ${ Cressida._options.auxiliary } be ${ message }`);
+    equal(instance(o, args), `${ Cressida._options.auxiliary } be ${ message }`);
   });
 
   negatives.map((o) => {
     equal(instance('foo', o, args), `foo ${ Cressida._options.auxiliary } not be ${ message }`);
+    equal(instance(o, args), `${ Cressida._options.auxiliary } not be ${ message }`);
   });
 }
 
@@ -192,19 +195,24 @@ describe('Cressida', () => {
     });
   });
   describe('options', () => {
-
-    describe('#auxiliary', () =>{
-      it('should set the options correctly', () => {
+    describe('#auxiliary', () => {
+      it('should set the `auxiliary` option correctly', () => {
         {
-          let Message = Cressida.create({auxiliary : 'must'});
-          equal(Message('foo', '!empty'), 'foo must not be empty.')
+          let Message = Cressida.create({auxiliary: 'must'});
+          equal(Message('foo', '!empty'), 'foo must not be empty.');
         }
 
         {
-          let Message = Cressida.create({auxiliary : 'can'});
-          equal(Message('foo', 'empty'), 'foo can be empty.')
+          let Message = Cressida.create({auxiliary: 'can'});
+          equal(Message('foo', 'empty'), 'foo can be empty.');
         }
-      })
+      });
+      it('should set the `includeName` option correctly', () => {
+        let Message = Cressida.create({includeName: false});
+
+        equal(Message('foo', '!empty'), 'should not be empty.');
+        equal(Message('foo', 'len', [10, 20]), 'should be between 10 to 20 characters.');
+      });
     });
 
   });


### PR DESCRIPTION
Contains:
- New option `includeName`. If this is false, name will ommitted
  from the generated message even if you provide a name.
- Throws an error if operator is not supported.
- Subjectless message.
  Example:

``` javascript
Message('!empty') // should not be empty.
```
